### PR TITLE
Added invert color palette option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The name of each field doesn't matter—the panel selects the first field of eac
 - **Group by** sets the size of each bucket.
 - **Calculation** sets calculation to use for reducing data within a bucket.
 - **Color palette** sets the colors to use for the heatmap. Select from any of the predefined color palettes, or select **Custom** to create your own.
-- **Invert color palette** inverts the currently selected color palette. This doesnot apply to **Custom** palette. 
+- **Invert color palette** inverts the currently selected color palette.
 
 #### Standard options
 

--- a/src/HeatmapPanel.tsx
+++ b/src/HeatmapPanel.tsx
@@ -77,7 +77,7 @@ export const HeatmapContainer: React.FC<HeatmapContainerProps> = ({
   // numeric field in the data frame.
   const fieldConfig = frame.fields.find(field => field.type === 'number')?.config.custom;
   const colorPalette = fieldConfig.colorPalette;
-  const invertPalette = fieldConfig.invertPalette; 
+  const invertPalette = fieldConfig.invertPalette;
   const colorSpace = fieldConfig.colorSpace;
   const thresholds: ThresholdsConfig = fieldConfig.thresholds ?? {
     mode: ThresholdsMode.Percentage,

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -4,86 +4,89 @@ import { ThresholdsConfig, ThresholdsMode } from '@grafana/data';
 type Interpolator = (t: number) => string;
 
 interface ColorScaleLookup {
-	[name: string]: Interpolator;
+  [name: string]: Interpolator;
 }
 
 const interpolators: ColorScaleLookup = {
-	// Diverging
-	interpolateSpectral: d3.interpolateSpectral,
-	interpolateRdYlGn: d3.interpolateRdYlGn,
+  // Diverging
+  interpolateSpectral: d3.interpolateSpectral,
+  interpolateRdYlGn: d3.interpolateRdYlGn,
 
-	// Single hue
-	interpolateBlues: d3.interpolateBlues,
-	interpolateGreens: d3.interpolateGreens,
-	interpolateGreys: d3.interpolateGreys,
-	interpolateOranges: d3.interpolateOranges,
-	interpolatePurples: d3.interpolatePurples,
-	interpolateReds: d3.interpolateReds,
+  // Single hue
+  interpolateBlues: d3.interpolateBlues,
+  interpolateGreens: d3.interpolateGreens,
+  interpolateGreys: d3.interpolateGreys,
+  interpolateOranges: d3.interpolateOranges,
+  interpolatePurples: d3.interpolatePurples,
+  interpolateReds: d3.interpolateReds,
 
-	// Multi-hue
-	interpolateBuGn: d3.interpolateBuGn,
-	interpolateBuPu: d3.interpolateBuPu,
-	interpolateGnBu: d3.interpolateGnBu,
-	interpolateOrRd: d3.interpolateOrRd,
-	interpolatePuBuGn: d3.interpolatePuBuGn,
-	interpolatePuBu: d3.interpolatePuBu,
-	interpolatePuRd: d3.interpolatePuRd,
-	interpolateRdPu: d3.interpolateRdPu,
-	interpolateYlGnBu: d3.interpolateYlGnBu,
-	interpolateYlGn: d3.interpolateYlGn,
-	interpolateYlOrBr: d3.interpolateYlOrBr,
-	interpolateYlOrRd: d3.interpolateYlOrRd
+  // Multi-hue
+  interpolateBuGn: d3.interpolateBuGn,
+  interpolateBuPu: d3.interpolateBuPu,
+  interpolateGnBu: d3.interpolateGnBu,
+  interpolateOrRd: d3.interpolateOrRd,
+  interpolatePuBuGn: d3.interpolatePuBuGn,
+  interpolatePuBu: d3.interpolatePuBu,
+  interpolatePuRd: d3.interpolatePuRd,
+  interpolateRdPu: d3.interpolateRdPu,
+  interpolateYlGnBu: d3.interpolateYlGnBu,
+  interpolateYlGn: d3.interpolateYlGn,
+  interpolateYlOrBr: d3.interpolateYlOrBr,
+  interpolateYlOrRd: d3.interpolateYlOrRd,
 };
 
 // makeSpectrumColorScale returns a sequential scale that maps numbers between
 // min and max, using a given color palette.
 export const makeSpectrumColorScale = (
-	palette: string,
-	min: number,
-	max: number,
-	invertPalette: boolean
+  palette: string,
+  min: number,
+  max: number,
+  invertPalette: boolean
 ): d3.ScaleSequential<string> => {
-	if (invertPalette) {
-		return d3.scaleSequential(interpolators[palette]).domain([ max, min ]);
-	} else {
-		return d3.scaleSequential(interpolators[palette]).domain([ min, max ]);
-	}
+  if (invertPalette) {
+    return d3.scaleSequential(interpolators[palette]).domain([max, min]);
+  } else {
+    return d3.scaleSequential(interpolators[palette]).domain([min, max]);
+  }
 };
 
 interface InterpolatorLookup {
-	[name: string]: d3.InterpolatorFactory<string, string>;
+  [name: string]: d3.InterpolatorFactory<string, string>;
 }
 
 const interpolationMap: InterpolatorLookup = {
-	rgb: d3.interpolateRgb,
-	hsl: d3.interpolateHsl,
-	hcl: d3.interpolateHcl,
-	lab: d3.interpolateLab,
-	cubehelix: d3.interpolateCubehelix
+  rgb: d3.interpolateRgb,
+  hsl: d3.interpolateHsl,
+  hcl: d3.interpolateHcl,
+  lab: d3.interpolateLab,
+  cubehelix: d3.interpolateCubehelix,
 };
 
 // makeCustomColorScale returns a linear scale that maps numbers between min and
 // max. Instead of using a predefined D3 interpolator, the color palette is
 // created from a thresholds configuration.
 export const makeCustomColorScale = (colorSpace: string, min: number, max: number, thresholds: ThresholdsConfig) => {
-	const interpolator = interpolationMap[colorSpace];
-	const colorRange = thresholds.steps.map(({ color }) => color);
+  const interpolator = interpolationMap[colorSpace];
+  const colorRange = thresholds.steps.map(({ color }) => color);
 
-	if (thresholds.mode === ThresholdsMode.Absolute) {
-		return d3
-			.scaleLinear<string>()
-			.domain(thresholds.steps.map(({ value }) => (value >= 0 ? value : 0.0)))
-			.range(colorRange)
-			.interpolate(interpolator);
-	}
+  if (thresholds.mode === ThresholdsMode.Absolute) {
+    return d3
+      .scaleLinear<string>()
+      .domain(thresholds.steps.map(({ value }) => (value >= 0 ? value : 0.0)))
+      .range(colorRange)
+      .interpolate(interpolator);
+  }
 
-	// If the thresholds mode is `percentage`, we first need to map the percentage
-	// from [0, 100] to [min, max].
-	const scale = d3.scaleLinear().domain([ 0, 100 ]).range([ min, max ]);
+  // If the thresholds mode is `percentage`, we first need to map the percentage
+  // from [0, 100] to [min, max].
+  const scale = d3
+    .scaleLinear()
+    .domain([0, 100])
+    .range([min, max]);
 
-	return d3
-		.scaleLinear<string>()
-		.domain(thresholds.steps.map(({ value }) => (value >= 0 ? scale(value) : 0.0)))
-		.range(colorRange)
-		.interpolate(interpolator);
+  return d3
+    .scaleLinear<string>()
+    .domain(thresholds.steps.map(({ value }) => (value >= 0 ? scale(value) : 0.0)))
+    .range(colorRange)
+    .interpolate(interpolator);
 };

--- a/src/components/HeatmapChart.test.tsx
+++ b/src/components/HeatmapChart.test.tsx
@@ -6,39 +6,43 @@ import { dateTime } from '@grafana/data';
 import { HeatmapChart } from './HeatmapChart';
 
 describe('HeatmapChart', () => {
-	it('renders the component', () => {
-		const numDays = 7;
-		const points = [];
-		for (let d = 0; d < numDays; d++) {
-			for (let h = 0; h < 24; h++) {
-				points.push({
-					dayMillis: dateTime('2020-05-20T00:00:00Z').add(d, 'day').valueOf(),
-					bucketStartMillis: dateTime('2020-05-20T00:00:00Z').add(h, 'hour').valueOf(),
-					value: d * h
-				});
-			}
-		}
-		const colorScale = makeSpectrumColorScale('interpolateSpectral', 0, numDays * 24, true);
-		const data = {
-			numBuckets: 24,
-			min: 0,
-			max: numDays * 24,
-			displayProcessor: (t: number) => ({ numeric: t, text: t.toString() }),
-			points: points
-		};
+  it('renders the component', () => {
+    const numDays = 7;
+    const points = [];
+    for (let d = 0; d < numDays; d++) {
+      for (let h = 0; h < 24; h++) {
+        points.push({
+          dayMillis: dateTime('2020-05-20T00:00:00Z')
+            .add(d, 'day')
+            .valueOf(),
+          bucketStartMillis: dateTime('2020-05-20T00:00:00Z')
+            .add(h, 'hour')
+            .valueOf(),
+          value: d * h,
+        });
+      }
+    }
+    const colorScale = makeSpectrumColorScale('interpolateSpectral', 0, numDays * 24, true);
+    const data = {
+      numBuckets: 24,
+      min: 0,
+      max: numDays * 24,
+      displayProcessor: (t: number) => ({ numeric: t, text: t.toString() }),
+      points: points,
+    };
 
-		const { asFragment } = render(
-			<svg xmlns="http://www.w3.org/2000/svg">
-				<HeatmapChart
-					width={1000}
-					height={500}
-					timeZone="utc"
-					data={data}
-					dailyInterval={[ 0, 24 ]}
-					colorScale={colorScale}
-				/>
-			</svg>
-		);
-		expect(asFragment()).toMatchSnapshot();
-	});
+    const { asFragment } = render(
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <HeatmapChart
+          width={1000}
+          height={500}
+          timeZone="utc"
+          data={data}
+          dailyInterval={[0, 24]}
+          colorScale={colorScale}
+        />
+      </svg>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/components/Legend.test.tsx
+++ b/src/components/Legend.test.tsx
@@ -5,15 +5,15 @@ import { makeSpectrumColorScale } from '../colors';
 import { Legend } from './Legend';
 
 describe('Legend', () => {
-	it('renders the component', () => {
-		const colorScale = makeSpectrumColorScale('interpolateSpectral', 0, 100, true);
-		const display = (t: number) => ({ numeric: t, text: t.toString() });
+  it('renders the component', () => {
+    const colorScale = makeSpectrumColorScale('interpolateSpectral', 0, 100, true);
+    const display = (t: number) => ({ numeric: t, text: t.toString() });
 
-		const { asFragment } = render(
-			<svg xmlns="http://www.w3.org/2000/svg">
-				<Legend width={300} height={100} colorScale={colorScale} min={0} max={100} display={display} />
-			</svg>
-		);
-		expect(asFragment()).toMatchSnapshot();
-	});
+    const { asFragment } = render(
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <Legend width={300} height={100} colorScale={colorScale} min={0} max={100} display={display} />
+      </svg>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,10 +1,10 @@
 import { PanelPlugin } from '@grafana/data';
 import {
-	FieldType,
-	FieldConfigProperty,
-	dateTime,
-	standardEditorsRegistry,
-	thresholdsOverrideProcessor
+  FieldType,
+  FieldConfigProperty,
+  dateTime,
+  standardEditorsRegistry,
+  thresholdsOverrideProcessor,
 } from '@grafana/data';
 import { HeatmapOptions, HeatmapFieldConfig } from './types';
 import { HeatmapPanel } from './HeatmapPanel';
@@ -13,143 +13,149 @@ import * as d3 from 'd3';
 
 const paletteSelected = (colorPalette: string) => (config: HeatmapFieldConfig) => config.colorPalette === colorPalette;
 const paletteNotSelected = (colorPalette: string) => (config: HeatmapFieldConfig) =>
-	config.colorPalette !== colorPalette;
+  config.colorPalette !== colorPalette;
 
 export const plugin = new PanelPlugin<HeatmapOptions, HeatmapFieldConfig>(HeatmapPanel)
-	.useFieldConfig({
-		useCustomConfig: (builder) => {
-			builder
-				.addSelect({
-					path: 'groupBy',
-					name: 'Group by',
-					settings: {
-						options: [
-							{ value: 15, label: '15 minutes' },
-							{ value: 30, label: '30 minutes' },
-							{ value: 60, label: '60 minutes' }
-						]
-					},
-					defaultValue: 60
-				})
-				.addSelect({
-					path: 'calculation',
-					name: 'Calculation',
-					settings: {
-						options: [
-							{ value: 'mean', label: 'Mean' },
-							{ value: 'sum', label: 'Sum' },
-							{ value: 'count', label: 'Count' },
-							{ value: 'min', label: 'Min' },
-							{ value: 'max', label: 'Max' },
-							{ value: 'first', label: 'First' },
-							{ value: 'last', label: 'Last' }
-						]
-					},
-					defaultValue: 'mean'
-				})
-				.addSelect({
-					path: 'colorPalette',
-					name: 'Color palette',
-					settings: {
-						options: [ { value: 'custom', label: 'Custom' }, ...predefinedColorPalettes ]
-					},
-					defaultValue: 'interpolateSpectral'
-				})
-				.addBooleanSwitch({
-					path: 'invertPalette',
-					name: 'Invert Color Palette',
-					defaultValue: false,
-					showIf: paletteNotSelected('custom')
-				})
-				.addSelect({
-					path: 'colorSpace',
-					name: 'Color space',
-					settings: {
-						options: [
-							{ value: 'rgb', label: 'RGB' },
-							{ value: 'hsl', label: 'HSL' },
-							{ value: 'hcl', label: 'HCL' },
-							{ value: 'lab', label: 'Lab' },
-							{ value: 'cubehelix', label: 'Cubehelix' }
-						]
-					},
-					showIf: paletteSelected('custom'),
-					defaultValue: 'rgb'
-				})
-				.addCustomEditor({
-					id: 'thresholds',
-					path: 'thresholds',
-					name: 'Thresholds',
-					editor: standardEditorsRegistry.get('thresholds').editor as any,
-					override: standardEditorsRegistry.get('thresholds').editor as any,
-					process: thresholdsOverrideProcessor,
-					shouldApply: (field) => field.type === FieldType.number,
-					showIf: paletteSelected('custom')
-				});
-		},
-		standardOptions: [
-			FieldConfigProperty.Min,
-			FieldConfigProperty.Max,
-			FieldConfigProperty.Decimals,
-			FieldConfigProperty.Unit
-		]
-	})
-	.setPanelOptions((builder) => {
-		return builder
-			.addSelect({
-				path: 'from',
-				name: 'From',
-				description: '',
-				settings: {
-					options: d3.range(0, 24, 1).map((h) => ({
-						label: dateTime().startOf('day').add(h, 'hour').format('HH:mm'),
-						value: `${h}`
-					}))
-				},
-				defaultValue: '0'
-			})
-			.addSelect({
-				path: 'to',
-				name: 'To',
-				settings: {
-					options: d3.range(0, 24, 1).map((h) => ({
-						label: dateTime().startOf('day').add(h, 'hour').format('HH:mm'),
-						value: `${h}`
-					}))
-				},
-				defaultValue: '0'
-			})
-			.addBooleanSwitch({
-				path: 'showLegend',
-				name: 'Show legend',
-				defaultValue: true
-			});
-	});
+  .useFieldConfig({
+    useCustomConfig: builder => {
+      builder
+        .addSelect({
+          path: 'groupBy',
+          name: 'Group by',
+          settings: {
+            options: [
+              { value: 15, label: '15 minutes' },
+              { value: 30, label: '30 minutes' },
+              { value: 60, label: '60 minutes' },
+            ],
+          },
+          defaultValue: 60,
+        })
+        .addSelect({
+          path: 'calculation',
+          name: 'Calculation',
+          settings: {
+            options: [
+              { value: 'mean', label: 'Mean' },
+              { value: 'sum', label: 'Sum' },
+              { value: 'count', label: 'Count' },
+              { value: 'min', label: 'Min' },
+              { value: 'max', label: 'Max' },
+              { value: 'first', label: 'First' },
+              { value: 'last', label: 'Last' },
+            ],
+          },
+          defaultValue: 'mean',
+        })
+        .addSelect({
+          path: 'colorPalette',
+          name: 'Color palette',
+          settings: {
+            options: [{ value: 'custom', label: 'Custom' }, ...predefinedColorPalettes],
+          },
+          defaultValue: 'interpolateSpectral',
+        })
+        .addBooleanSwitch({
+          path: 'invertPalette',
+          name: 'Invert Color Palette',
+          defaultValue: false,
+          showIf: paletteNotSelected('custom'),
+        })
+        .addSelect({
+          path: 'colorSpace',
+          name: 'Color space',
+          settings: {
+            options: [
+              { value: 'rgb', label: 'RGB' },
+              { value: 'hsl', label: 'HSL' },
+              { value: 'hcl', label: 'HCL' },
+              { value: 'lab', label: 'Lab' },
+              { value: 'cubehelix', label: 'Cubehelix' },
+            ],
+          },
+          showIf: paletteSelected('custom'),
+          defaultValue: 'rgb',
+        })
+        .addCustomEditor({
+          id: 'thresholds',
+          path: 'thresholds',
+          name: 'Thresholds',
+          editor: standardEditorsRegistry.get('thresholds').editor as any,
+          override: standardEditorsRegistry.get('thresholds').editor as any,
+          process: thresholdsOverrideProcessor,
+          shouldApply: field => field.type === FieldType.number,
+          showIf: paletteSelected('custom'),
+        });
+    },
+    standardOptions: [
+      FieldConfigProperty.Min,
+      FieldConfigProperty.Max,
+      FieldConfigProperty.Decimals,
+      FieldConfigProperty.Unit,
+    ],
+  })
+  .setPanelOptions(builder => {
+    return builder
+      .addSelect({
+        path: 'from',
+        name: 'From',
+        description: '',
+        settings: {
+          options: d3.range(0, 24, 1).map(h => ({
+            label: dateTime()
+              .startOf('day')
+              .add(h, 'hour')
+              .format('HH:mm'),
+            value: `${h}`,
+          })),
+        },
+        defaultValue: '0',
+      })
+      .addSelect({
+        path: 'to',
+        name: 'To',
+        settings: {
+          options: d3.range(0, 24, 1).map(h => ({
+            label: dateTime()
+              .startOf('day')
+              .add(h, 'hour')
+              .format('HH:mm'),
+            value: `${h}`,
+          })),
+        },
+        defaultValue: '0',
+      })
+      .addBooleanSwitch({
+        path: 'showLegend',
+        name: 'Show legend',
+        defaultValue: true,
+      });
+  });
 
 const predefinedColorPalettes = [
-	// Diverging
-	{ label: 'Spectral', value: 'interpolateSpectral' },
-	{ label: 'RdYlGn', value: 'interpolateRdYlGn' },
+  // Diverging
+  { label: 'Spectral', value: 'interpolateSpectral' },
+  { label: 'RdYlGn', value: 'interpolateRdYlGn' },
 
-	// Sequential (Single Hue)
-	{ label: 'Blues', value: 'interpolateBlues' },
-	{ label: 'Greens', value: 'interpolateGreens' },
-	{ label: 'Greys', value: 'interpolateGreys' },
-	{ label: 'Oranges', value: 'interpolateOranges' },
-	{ label: 'Purples', value: 'interpolatePurples' },
-	{ label: 'Reds', value: 'interpolateReds' },
+  // Sequential (Single Hue)
+  { label: 'Blues', value: 'interpolateBlues' },
+  { label: 'Greens', value: 'interpolateGreens' },
+  { label: 'Greys', value: 'interpolateGreys' },
+  { label: 'Oranges', value: 'interpolateOranges' },
+  { label: 'Purples', value: 'interpolatePurples' },
+  { label: 'Reds', value: 'interpolateReds' },
 
-	// Sequential (Multi-Hue)
-	{ label: 'BuGn', value: 'interpolateBuGn' },
-	{ label: 'BuPu', value: 'interpolateBuPu' },
-	{ label: 'GnBu', value: 'interpolateGnBu' },
-	{ label: 'OrRd', value: 'interpolateOrRd' },
-	{ label: 'PuBuGn', value: 'interpolatePuBuGn' },
-	{ label: 'PuBu', value: 'interpolatePuBu' },
-	{ label: 'PuRd', value: 'interpolatePuRd' },
-	{ label: 'RdPu', value: 'interpolateRdPu' },
-	{ label: 'YlGnBu', value: 'interpolateYlGnBu' },
-	{ label: 'YlGn', value: 'interpolateYlGn' },
-	{ label: 'YlOrBr', value: 'interpolateYlOrBr' },
-	{ label: 'YlOrRd', value: 'interpolateYlOrRd' }
+  // Sequential (Multi-Hue)
+  { label: 'BuGn', value: 'interpolateBuGn' },
+  { label: 'BuPu', value: 'interpolateBuPu' },
+  { label: 'GnBu', value: 'interpolateGnBu' },
+  { label: 'OrRd', value: 'interpolateOrRd' },
+  { label: 'PuBuGn', value: 'interpolatePuBuGn' },
+  { label: 'PuBu', value: 'interpolatePuBu' },
+  { label: 'PuRd', value: 'interpolatePuRd' },
+  { label: 'RdPu', value: 'interpolateRdPu' },
+  { label: 'YlGnBu', value: 'interpolateYlGnBu' },
+  { label: 'YlGn', value: 'interpolateYlGn' },
+  { label: 'YlOrBr', value: 'interpolateYlOrBr' },
+  { label: 'YlOrRd', value: 'interpolateYlOrRd' },
 ];

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ import * as d3 from 'd3';
 
 const paletteSelected = (colorPalette: string) => (config: HeatmapFieldConfig) => config.colorPalette === colorPalette;
 const paletteNotSelected = (colorPalette: string) => (config: HeatmapFieldConfig) =>
-	config.colorPalette != colorPalette;
+	config.colorPalette !== colorPalette;
 
 export const plugin = new PanelPlugin<HeatmapOptions, HeatmapFieldConfig>(HeatmapPanel)
 	.useFieldConfig({

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,20 +3,20 @@ import { ThresholdsConfig } from '@grafana/data';
 type Calculation = 'mean' | 'sum' | 'count' | 'min' | 'max' | 'first' | 'last';
 
 export interface HeatmapOptions {
-	showLegend: boolean;
-	from: string;
-	to: string;
+  showLegend: boolean;
+  from: string;
+  to: string;
 }
 
 export interface HeatmapFieldConfig {
-	colorPalette: string;
-	invertPalette: boolean;
+  colorPalette: string;
+  invertPalette: boolean;
 
-	// Options for custom color palettes.
-	colorSpace: string;
-	thresholds: ThresholdsConfig;
+  // Options for custom color palettes.
+  colorSpace: string;
+  thresholds: ThresholdsConfig;
 
-	// Options for reducing buckets.
-	calculation: Calculation;
-	groupBy: number;
+  // Options for reducing buckets.
+  calculation: Calculation;
+  groupBy: number;
 }


### PR DESCRIPTION
Added an option to invert the currently selected color palette. 

![image](https://user-images.githubusercontent.com/42851980/89335676-0e03e080-d634-11ea-8b21-9f63d1042bb3.png)

Originally, the color scheme went from light to dark and it was not enough for some of the projects. This option allows user to select the palette from dark to light or vice versa. Invert color pallet option only appears when the selected color palette is not custom. 